### PR TITLE
legacy build renamed some script files

### DIFF
--- a/com.etlegacy.ETLegacy.yaml
+++ b/com.etlegacy.ETLegacy.yaml
@@ -153,16 +153,16 @@ modules:
       - "desktop-file-edit --set-key='Name' --set-value='ET: Legacy' /app/share/applications/com.etlegacy.ETLegacy.desktop"
     sources:
       - type: file
-        url: https://www.etlegacy.com/download/file/539
-        sha256: fa467a8b17a8242e25814db981fad4d78fbf39d7bec4937f74aab46603e7dabb
+        url: https://www.etlegacy.com/download/file/554
+        sha256: ed8b4abb6e3cd13c1a3af2d7e4526ede260abee4afbdc6838210d742d98bdab5
         dest-filename: etl.tar.gz
       # This is just a canary. We don't build from source because that's not reasonable in our
       # case but we can use this repository to warn us when there is a release.
       - type: git
         url: https://github.com/etlegacy/etlegacy
         disable-submodules: true
-        commit: ba7786a59917c39099c32f6da6f8eb55ba3163e6
-        tag: v2.81.0
+        commit: 956269f4c13ebe31ba2a0f0b805588383209bd5b
+        tag: v2.81.1
         x-checker-data:
           type: git
           tag-pattern: ^v([\d.]+)$

--- a/com.etlegacy.ETLegacy.yaml
+++ b/com.etlegacy.ETLegacy.yaml
@@ -122,10 +122,10 @@ modules:
     buildsystem: simple
     build-commands:
       - tar -xf ./etl.tar.gz
-      - install -Dm744 ./etlegacy-*-i386/etl.x86 -t /app/bin/
-      - mv /app/bin/etl.x86 /app/bin/etl
-      - install -Dm744 ./etlegacy-*-i386/etlded.x86 -t /app/bin/
-      - mv /app/bin/etlded.x86 /app/bin/etlded
+      - install -Dm744 ./etlegacy-*-i386/etl.i386 -t /app/bin/
+      - mv /app/bin/etl.i386 /app/bin/etl
+      - install -Dm744 ./etlegacy-*-i386/etlded.i386 -t /app/bin/
+      - mv /app/bin/etlded.i386 /app/bin/etlded
       - install -Dm744 ./etlegacy-*-i386/librenderer_opengl1_i386.so -t /app/bin/
       # Game assets
       - cp -r ./etlegacy-*-i386/etmain /app/bin/

--- a/com.etlegacy.ETLegacy.yaml
+++ b/com.etlegacy.ETLegacy.yaml
@@ -148,7 +148,7 @@ modules:
       - ln -s /app/extra/pak1.pk3 /app/bin/etmain/pak1.pk3
       - ln -s /app/extra/pak2.pk3 /app/bin/etmain/pak2.pk3
       # set basepath, and change name to be generic
-      - mv /app/share/applications/com.etlegacy.ETLegacy.x86.desktop /app/share/applications/com.etlegacy.ETLegacy.desktop
+      - mv /app/share/applications/com.etlegacy.ETLegacy.i386.desktop /app/share/applications/com.etlegacy.ETLegacy.desktop
       - "desktop-file-edit --set-key='Exec' --set-value='/app/bin/etl.sh +connect %u' /app/share/applications/com.etlegacy.ETLegacy.desktop"        
       - "desktop-file-edit --set-key='Name' --set-value='ET: Legacy' /app/share/applications/com.etlegacy.ETLegacy.desktop"
     sources:


### PR DESCRIPTION
Files such as the .sh files and desktop files are generated during the build and their filenames are also generated by the build system. This caused the '_x86' postfixes to change to the '.i386' instead. Now the filenames are better inline with other used names in the bundle.